### PR TITLE
Update docker-compose files

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,0 +1,29 @@
+## Introduction and files overview
+
+File `docker-compose.yml` contains configuration that uses images for services pulled from Docker Hub.
+
+File `docker-compose-dev.yml` contains configuration that builds file storage service, job service and worker service from scratch.
+
+File `docker-compose.override.yml` contains configuration necessary to run api-gateway module to achieve monolith-like behaviour of all other services.
+
+File `.env` contains different security-sensitive settings.
+
+## Run application with images pulled from Docker Hub
+In order to start the application from Docker Hub images in the current directory run the following command to start docker compose:
+
+`docker-compose up`
+
+It will automatically pick up and use configurations from `docker-compose.yml` and `docker-compose.override.yml` with security-sensitive settings obtained from `.env` file.
+
+
+Note: update `.env` file contents to define custom security-sensitive settings.
+
+## Run application with local build
+In order to build and run the application from scratch, e.g. during the development process, run the following command:
+
+`docker-compose -f docker-compose-dev.yml -f docker-compose.override.yml up`
+
+It will pick up and use configurations from `docker-compose-dev.yml` and `docker-compose.override.yml` with security-sensitive settings obtained from `.env` file.
+
+Note: before running dev version of docker compose ensure that updated jar files have been built in project root directory using Maven:
+`mvn clean package`

--- a/.docker/api-gateway/conf.d/dev.conf
+++ b/.docker/api-gateway/conf.d/dev.conf
@@ -30,7 +30,7 @@ server {
     }
 
     location /api/profiles {
-        proxy_pass                       http://job-service:8080/api/profiles;
+        proxy_pass                       http://host.docker.internal:8091/api/profiles;
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
     }

--- a/.docker/docker-compose-dev.yml
+++ b/.docker/docker-compose-dev.yml
@@ -8,12 +8,12 @@ services:
       POSTGRES_PASSWORD: ${LOCAL_STORAGE_SERVICE_DATABASE_PASSWORD}
       POSTGRES_DB: verapdfdb
     volumes:
-      - type: volume
-        source: localstorage_database_data
-        target: /var/lib/postgresql/data
+        - type: volume
+          source: localstorage_database_data
+          target: /var/lib/postgresql/data
     restart: always
   file-storage:
-    image: verapdf/file-storage:latest
+    build: ../local-storage-service/server
     expose:
       - 8080
     depends_on:
@@ -41,13 +41,13 @@ services:
       POSTGRES_PASSWORD: ${JOB_SERVICE_DATABASE_PASSWORD}
       POSTGRES_DB: verapdfjobdb
     volumes:
-      - type: volume
-        source: jobservice_database_data
-        target: /var/lib/postgresql/data
+    - type: volume
+      source: jobservice_database_data
+      target: /var/lib/postgresql/data
     restart: always
 
   job-service:
-    image: verapdf/job-service:latest
+    build: ../job-service/server
     expose:
       - 8080
     depends_on:
@@ -85,12 +85,12 @@ services:
         target: /var/lib/rabbitmq/
 
   worker:
-    image: verapdf/worker:latest
+    build: ../worker
     restart: always
     depends_on:
-      - job-service
-      - file-storage
-      - queue
+    - job-service
+    - file-storage
+    - queue
     environment:
       AMQP_SERVER_HOST: queue
       AMQP_USER: ${AMQP_SERVER_USER}


### PR DESCRIPTION
Add docker-compose file that uses pre-built images from Docker Hub instead of building file-storage, job-service and worker modules.