### PR TITLE
Add support for automated docker builds

### DIFF
--- a/.docker/docker-compose-dev.yml
+++ b/.docker/docker-compose-dev.yml
@@ -13,7 +13,9 @@ services:
           target: /var/lib/postgresql/data
     restart: always
   file-storage:
-    build: ../local-storage-service/server
+    build:
+      context: ../local-storage-service/server
+      dockerfile: Dockerfile-dev
     expose:
       - 8080
     depends_on:
@@ -47,7 +49,9 @@ services:
     restart: always
 
   job-service:
-    build: ../job-service/server
+    build:
+      context: ../job-service/server
+      dockerfile: Dockerfile-dev
     expose:
       - 8080
     depends_on:
@@ -86,7 +90,9 @@ services:
         target: /var/lib/rabbitmq/
 
   worker:
-    build: ../worker
+    build:
+      context: ../worker
+      dockerfile: Dockerfile-dev
     restart: always
     depends_on:
     - job-service

--- a/job-service/server/Dockerfile
+++ b/job-service/server/Dockerfile
@@ -1,4 +1,13 @@
+FROM maven:3.8.1-jdk-11-slim AS MAVEN_BUILD
+
+# copy the pom and src code to the container
+COPY ./ ./
+
+# package our application code
+RUN mvn clean package
+
 FROM openjdk:11-jre
-COPY target/job-service-server.jar job-service-server.jar
+
+COPY --from=MAVEN_BUILD job-service/server/target/job-service-server.jar job-service-server.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "job-service-server.jar"]

--- a/job-service/server/Dockerfile-dev
+++ b/job-service/server/Dockerfile-dev
@@ -1,0 +1,4 @@
+FROM openjdk:11-jre
+COPY target/job-service-server.jar job-service-server.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "job-service-server.jar"]

--- a/local-storage-service/server/Dockerfile
+++ b/local-storage-service/server/Dockerfile
@@ -1,4 +1,13 @@
+FROM maven:3.8.1-jdk-11-slim AS MAVEN_BUILD
+
+# copy the pom and src code to the container
+COPY ./ ./
+
+# package our application code
+RUN mvn clean package
+
 FROM openjdk:11-jre
-COPY target/local-storage-service-server.jar local-storage-service-server.jar
+
+COPY --from=MAVEN_BUILD local-storage-service/server/target/local-storage-service-server.jar local-storage-service-server.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "local-storage-service-server.jar"]

--- a/local-storage-service/server/Dockerfile-dev
+++ b/local-storage-service/server/Dockerfile-dev
@@ -1,0 +1,4 @@
+FROM openjdk:11-jre
+COPY target/local-storage-service-server.jar local-storage-service-server.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "local-storage-service-server.jar"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,13 @@
+FROM maven:3.8.1-jdk-11-slim AS MAVEN_BUILD
+
+# copy the pom and src code to the container
+COPY ./ ./
+
+# package our application code
+RUN mvn clean package
+
 FROM openjdk:11-jre
-COPY target/worker.jar worker.jar
+
+COPY --from=MAVEN_BUILD worker/target/worker.jar worker.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "worker.jar"]
+ENTRYPOINT ["java", "-jar", "worker.jar"] "worker.jar"]

--- a/worker/Dockerfile-dev
+++ b/worker/Dockerfile-dev
@@ -1,0 +1,4 @@
+FROM openjdk:11-jre
+COPY target/worker.jar worker.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "worker.jar"]


### PR DESCRIPTION
Refactor Dockerfiles to automatically build and create an image for worker, job-service, file-storage-service. Add separate Dockerfiles-dev versions to be still able to build jars from scratch on server